### PR TITLE
move `test` package to `[dev-dependencies]` in mops.toml

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -7,5 +7,7 @@ keywords = [ "json", "parse", "stringfy", "validate" ]
 license = "MIT"
 
 [dependencies]
-test = "2.0.0"
 xtended-numbers = "0.3.1"
+
+[dev-dependencies]
+test = "2.0.0"


### PR DESCRIPTION
This will avoid installing `test` when users install the `json` package